### PR TITLE
Add Grok as a provider

### DIFF
--- a/Tests/GrokProvider/ChatTest.php
+++ b/Tests/GrokProvider/ChatTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Joomla\AI\Tests\GrokProvider;
+
+use Joomla\AI\Exception\AuthenticationException;
+use Joomla\AI\Exception\ProviderException;
+use Joomla\AI\Exception\RateLimitException;
+use Joomla\AI\Exception\UnserializableResponseException;
+use Joomla\AI\Provider\GrokProvider;
+use Joomla\Http\Http;
+use Joomla\Http\HttpFactory;
+use Joomla\Http\Response as HttpResponse;
+use PHPUnit\Framework\TestCase;
+
+class ChatTest extends TestCase
+{
+    public function testChatReturnsSuccessfulResponse(): void
+    {
+        // Test 1: Test chat method for successful completion
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $httpClientMock = $this->createMock(Http::class);
+        $httpFactoryMock->method('getHttp')->with([])->willReturn($httpClientMock);
+
+        $chatResponse = $this->createJsonResponse([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'created' => 1234567890,
+            'model' => 'grok-3-mini-fast',
+            'choices' => [
+                [
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello from Grok!',
+                    ],
+                    'finish_reason' => 'stop',
+                ],
+            ],
+            'usage' => [
+                'prompt_tokens' => 12,
+                'completion_tokens' => 9,
+                'total_tokens' => 21,
+            ],
+        ]);
+
+        $httpClientMock->expects($this->once())->method('post')->with(
+            'https://api.x.ai/v1/chat/completions',
+            $this->callback(function ($payload) {
+                $decoded = json_decode($payload, true);
+                $this->assertSame([['role' => 'user', 'content' => 'Hello there']], $decoded['messages']);
+                return true;
+            }),
+            $this->callback(function ($headers) {
+                $this->assertArrayHasKey('Authorization', $headers);
+                $this->assertSame('Bearer test-api-key', $headers['Authorization']);
+                return true;
+            }),
+            null
+        )->willReturn($chatResponse);
+
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+        $response = $provider->chat('Hello there');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Hello from Grok!', $response->getContent());
+
+        $metadata = $response->getMetadata();
+        $this->assertSame('grok-3-mini-fast', $metadata['model']);
+        $this->assertSame('stop', $metadata['finish_reason']);
+        $this->assertSame('Grok', $response->getProvider());
+    }
+
+    public function testChatStatusCodeReflectsLengthFinishReason(): void
+    {
+        // Test 2: Test chat method returns 206 status code when finish_reason is 'length'
+
+        $provider = $this->createProviderWithResponses([
+            $this->createJsonResponse([
+                'id' => 'chatcmpl-limit',
+                'object' => 'chat.completion',
+                'created' => 1234567890,
+                'model' => 'grok-3-mini-fast',
+                'choices' => [
+                    [
+                        'index' => 0,
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => 'Truncated reply',
+                        ],
+                        'finish_reason' => 'length',
+                    ],
+                ],
+                'usage' => ['prompt_tokens' => 100, 'completion_tokens' => 200, 'total_tokens' => 300],
+            ]),
+        ]);
+
+        $response = $provider->chat('Continue until you hit the limit.');
+
+        $this->assertSame(206, $response->getStatusCode());
+        $metadata = $response->getMetadata();
+        $this->assertSame('length', $metadata['finish_reason']);
+    }
+
+    public function testChatThrowsProviderExceptionWhenErrorReturned(): void
+    {
+        // Test 3: Test chat method raises ProviderException when API returns error
+
+        $provider = $this->createProviderWithResponses([
+            $this->createJsonResponse([
+                'error' => [
+                    'message' => 'Model overloaded',
+                    'type' => 'server_error',
+                ],
+            ]),
+        ]);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('Model overloaded');
+
+        $provider->chat('Hello?');
+    }
+
+    public function testChatThrowsProviderExceptionOnHttpFailure(): void
+    {
+        // Test 4: Test chat method raises ProviderException on HTTP 500 server error
+
+        $provider = $this->createProviderWithResponses([
+            $this->createJsonResponse([
+                'message' => 'Internal server error',
+            ], 500),
+        ]);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('Internal server error');
+
+        $provider->chat('Trigger failure');
+    }
+
+    public function testChatThrowsRateLimitExceptionWhenRateLimited(): void
+    {
+        // Test 5: Test chat method raises RateLimitException on too many requests
+
+        $provider = $this->createProviderWithResponses([
+            $this->createJsonResponse([
+                'message' => 'Rate limit exceeded',
+            ], 429),
+        ]);
+
+        $this->expectException(RateLimitException::class);
+        $this->expectExceptionMessage('Rate limit exceeded');
+
+        $provider->chat('Spam request');
+    }
+
+    public function testChatThrowsAuthenticationExceptionWhenApiKeyMissing(): void
+    {
+        // Test 6: Test chat method raises AuthenticationException when API key is missing
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+
+        $provider = new GrokProvider([], $httpFactoryMock);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('xAI API key not configured. Set XAI_API_KEY environment variable or provide api_key option.');
+
+        $provider->chat('Hi');
+    }
+
+    public function testChatThrowsUnserializableResponseExceptionForInvalidJson(): void
+    {
+        // Test 7: Test chat method raises UnserializableResponseException on invalid JSON
+
+        $invalidJsonResponse = new HttpResponse('php://memory', 200, ['Content-Type' => 'application/json']);
+        $invalidJsonResponse->getBody()->write('{invalid');
+
+        $provider = $this->createProviderWithResponses([$invalidJsonResponse]);
+
+        $this->expectException(UnserializableResponseException::class);
+        $this->expectExceptionMessage('Syntax error');
+
+        $provider->chat('Return malformed payload');
+    }
+
+    private function createProviderWithResponses(array $responses): GrokProvider
+    {
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $httpClientMock = $this->createMock(Http::class);
+
+        $httpFactoryMock->method('getHttp')->with([])->willReturn($httpClientMock);
+
+        $httpClientMock->method('post')->willReturnOnConsecutiveCalls(...$responses);
+
+        return new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+    }
+
+    private function createJsonResponse(array $payload, int $status = 200): HttpResponse
+    {
+        $response = new HttpResponse('php://memory', $status, ['Content-Type' => 'application/json']);
+        $response->getBody()->write(json_encode($payload));
+
+        return $response;
+    }
+}

--- a/Tests/GrokProvider/EmbeddingTest.php
+++ b/Tests/GrokProvider/EmbeddingTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Joomla\AI\Tests\GrokProvider;
+
+use Joomla\AI\Exception\InvalidArgumentException;
+use Joomla\AI\Exception\ProviderException;
+use Joomla\AI\Exception\UnserializableResponseException;
+use Joomla\AI\Provider\GrokProvider;
+use Joomla\Http\Http;
+use Joomla\Http\HttpFactory;
+use Joomla\Http\Response as HttpResponse;
+use PHPUnit\Framework\TestCase;
+
+class EmbeddingTest extends TestCase
+{
+    public function testCreateEmbeddingsReturnsVectorSuccessfully(): void
+    {
+        // Test 1: Test createEmbeddings returns float embedding successfully
+
+        $embeddingResponse = $this->createJsonResponse([
+            'object' => 'list',
+            'model' => 'v1',
+            'data' => [
+                [
+                    'object' => 'embedding',
+                    'index' => 0,
+                    'embedding' => [0.12, -0.34, 0.56],
+                ],
+            ],
+            'usage' => ['prompt_tokens' => 8, 'total_tokens' => 8],
+        ]);
+
+        $provider = $this->createProviderWithResponses($embeddingResponse);
+
+        $response = $provider->createEmbeddings('Embed this text', 'v1');
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $decodedContent = json_decode($response->getContent(), true);
+        $this->assertSame([0.12, -0.34, 0.56], $decodedContent);
+
+        $metadata = $response->getMetadata();
+        $this->assertSame('v1', $metadata['model']);
+        $this->assertSame(1, $metadata['embedding_count']);
+        $this->assertSame('float', $metadata['encoding_format']);
+        $this->assertSame('string', $metadata['input_type']);
+        $this->assertEquals(['prompt_tokens' => 8, 'total_tokens' => 8], $metadata['usage']);
+    }
+
+    public function testCreateEmbeddingsReturnsMultipleVectors(): void
+    {
+        // Test 2: Test createEmbeddings returns multiple embedding vectors for array input
+
+        $embeddingResponse = $this->createJsonResponse([
+            'object' => 'list',
+            'model' => 'v1',
+            'data' => [
+                [
+                    'object' => 'embedding',
+                    'index' => 0,
+                    'embedding' => [0.1, 0.2, 0.3],
+                ],
+                [
+                    'object' => 'embedding',
+                    'index' => 1,
+                    'embedding' => [0.4, 0.5, 0.6],
+                ],
+            ],
+            'usage' => ['prompt_tokens' => 12, 'total_tokens' => 12],
+        ]);
+
+        $provider = $this->createProviderWithResponses($embeddingResponse);
+
+        $response = $provider->createEmbeddings(['First text', 'Second text'], 'v1');
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $decodedContent = json_decode($response->getContent(), true);
+        $this->assertCount(2, $decodedContent);
+
+        $metadata = $response->getMetadata();
+        $this->assertSame(2, $metadata['embedding_count']);
+        $this->assertSame('array', $metadata['input_type']);
+    }
+
+    public function testCreateEmbeddingsThrowsOnInvalidEncodingFormat(): void
+    {
+        // Test 3: Test createEmbeddings raises InvalidArgumentException on invalid encoding format
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Encoding format must be 'float' or 'base64'");
+
+        $provider->createEmbeddings('test', 'v1', ['encoding_format' => 'hex']);
+    }
+
+    public function testCreateEmbeddingsThrowsProviderExceptionOnError(): void
+    {
+        // Test 4: Test createEmbeddings raises ProviderException on server error
+
+        $errorResponse = $this->createJsonResponse([
+            'error' => [
+                'message' => 'Embeddings API error',
+                'type' => 'server_error',
+            ],
+        ], 500);
+
+        $provider = $this->createProviderWithResponses($errorResponse);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('Embeddings API error');
+
+        $provider->createEmbeddings('trigger error', 'v1');
+    }
+
+    public function testCreateEmbeddingsThrowsUnserializableResponseException(): void
+    {
+        // Test 5: Test createEmbeddings raises UnserializableResponseException on invalid JSON
+
+        $invalidResponse = new HttpResponse('php://memory', 200, ['Content-Type' => 'application/json']);
+        $invalidResponse->getBody()->write('{ not valid json');
+
+        $provider = $this->createProviderWithResponses($invalidResponse);
+
+        $this->expectException(UnserializableResponseException::class);
+        $this->expectExceptionMessage('Syntax error');
+
+        $provider->createEmbeddings('bad json', 'v1');
+    }
+
+    private function createProviderWithResponses(HttpResponse ...$responses): GrokProvider
+    {
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $httpClientMock = $this->createMock(Http::class);
+
+        $httpFactoryMock->method('getHttp')->willReturn($httpClientMock);
+
+        if (!empty($responses)) {
+            $httpClientMock->method('post')->willReturnOnConsecutiveCalls(...$responses);
+        }
+
+        return new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+    }
+
+    private function createJsonResponse(array $payload, int $status = 200): HttpResponse
+    {
+        $response = new HttpResponse('php://memory', $status, ['Content-Type' => 'application/json']);
+        $response->getBody()->write(json_encode($payload));
+
+        return $response;
+    }
+}

--- a/Tests/GrokProvider/ImageTest.php
+++ b/Tests/GrokProvider/ImageTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Joomla\AI\Tests\GrokProvider;
+
+use Joomla\AI\Exception\InvalidArgumentException;
+use Joomla\AI\Exception\ProviderException;
+use Joomla\AI\Exception\UnserializableResponseException;
+use Joomla\AI\Provider\GrokProvider;
+use Joomla\Http\Http;
+use Joomla\Http\HttpFactory;
+use Joomla\Http\Response as HttpResponse;
+use PHPUnit\Framework\TestCase;
+
+class ImageTest extends TestCase
+{
+    public function testGenerateImageReturnsUrlSuccessfully(): void
+    {
+        // Test 1: Test generateImage method returns URL content successfully
+
+        $url = 'https://example.com/generated-image.png';
+
+        $imageResponse = $this->createJsonResponse([
+            'created' => 1234567890,
+            'data' => [
+                [
+                    'url' => $url,
+                    'revised_prompt' => 'A vivid mountain landscape',
+                ],
+            ],
+        ]);
+
+        $provider = $this->createProviderWithResponses($imageResponse);
+
+        $response = $provider->generateImage('A mountain landscape', [
+            'model' => 'grok-2-image-latest',
+            'response_format' => 'url',
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($url, $response->getContent());
+
+        $metadata = $response->getMetadata();
+        $this->assertSame('grok-2-image-latest', $metadata['model']);
+        $this->assertSame('url', $metadata['response_format']);
+        $this->assertSame(1, $metadata['image_count']);
+        $this->assertSame($url, $metadata['images'][0]['url']);
+        $this->assertSame('A vivid mountain landscape', $metadata['images'][0]['revised_prompt']);
+    }
+
+    public function testGenerateImageReturnsBase64Successfully(): void
+    {
+        // Test 2: Test generateImage method returns base64 content successfully
+
+        $base64Image = base64_encode('fake-image-data');
+
+        $imageResponse = $this->createJsonResponse([
+            'created' => 1234567890,
+            'model' => 'grok-2-image-latest',
+            'data' => [
+                ['b64_json' => $base64Image],
+            ],
+        ]);
+
+        $provider = $this->createProviderWithResponses($imageResponse);
+
+        $response = $provider->generateImage('A scenic sunset', [
+            'model' => 'grok-2-image-latest',
+            'response_format' => 'b64_json',
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($base64Image, $response->getContent());
+
+        $metadata = $response->getMetadata();
+        $this->assertSame('b64_json', $metadata['response_format']);
+        $this->assertSame(1, $metadata['image_count']);
+        $this->assertSame($base64Image, $metadata['images'][0]['b64_json']);
+    }
+
+    public function testGenerateImageReturnsMultipleImages(): void
+    {
+        // Test 3: Test generateImage method returns multiple images when n > 1
+
+        $url1 = 'https://example.com/image1.png';
+        $url2 = 'https://example.com/image2.png';
+
+        $imageResponse = $this->createJsonResponse([
+            'created' => 1234567890,
+            'data' => [
+                ['url' => $url1],
+                ['url' => $url2],
+            ],
+        ]);
+
+        $provider = $this->createProviderWithResponses($imageResponse);
+
+        $response = $provider->generateImage('Two cats', [
+            'model' => 'grok-2-image-latest',
+            'n' => 2,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $metadata = $response->getMetadata();
+        $this->assertSame(2, $metadata['image_count']);
+        $this->assertSame($url1, $metadata['images'][0]['url']);
+        $this->assertSame($url2, $metadata['images'][1]['url']);
+    }
+
+    public function testGenerateImageThrowsOnInvalidN(): void
+    {
+        // Test 4: Test generateImage method raises InvalidArgumentException when n is out of range
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be between 1 and 10');
+
+        $provider->generateImage('A cat', ['n' => 15]);
+    }
+
+    public function testGenerateImageThrowsOnInvalidResponseFormat(): void
+    {
+        // Test 5: Test generateImage method raises InvalidArgumentException on invalid response format
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Response format must be either "url" or "b64_json"');
+
+        $provider->generateImage('A dog', ['response_format' => 'invalid']);
+    }
+
+    public function testGenerateImageThrowsProviderExceptionOnError(): void
+    {
+        // Test 6: Test generateImage method raises ProviderException on API error
+
+        $errorResponse = $this->createJsonResponse([
+            'error' => [
+                'message' => 'Invalid request',
+                'type' => 'invalid_request_error',
+            ],
+        ], 400);
+
+        $provider = $this->createProviderWithResponses($errorResponse);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('Invalid request');
+
+        $provider->generateImage('Bad request');
+    }
+
+    public function testEditImageThrowsProviderException(): void
+    {
+        // Test 7: Test editImage method raises ProviderException as Grok does not support image editing
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('Image editing is not supported');
+
+        $provider->editImage('image.png', 'Edit this');
+    }
+
+    public function testCreateImageVariationThrowsProviderException(): void
+    {
+        // Test 8: Test createImageVariation method raises ProviderException as Grok does not support image variations
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('Image variations are not supported');
+
+        $provider->createImageVariation('image.png');
+    }
+
+    private function createProviderWithResponses(HttpResponse ...$responses): GrokProvider
+    {
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $httpClientMock = $this->createMock(Http::class);
+
+        $httpFactoryMock->method('getHttp')->willReturn($httpClientMock);
+
+        if (!empty($responses)) {
+            $httpClientMock->method('post')->willReturnOnConsecutiveCalls(...$responses);
+        }
+
+        return new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+    }
+
+    private function createJsonResponse(array $payload, int $status = 200): HttpResponse
+    {
+        $response = new HttpResponse('php://memory', $status, ['Content-Type' => 'application/json']);
+        $response->getBody()->write(json_encode($payload));
+
+        return $response;
+    }
+}

--- a/Tests/GrokProvider/ModelTest.php
+++ b/Tests/GrokProvider/ModelTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Joomla\AI\Tests\GrokProvider;
+
+use Joomla\AI\Provider\GrokProvider;
+use Joomla\Http\Http;
+use Joomla\Http\HttpFactory;
+use Joomla\Http\Response as HttpResponse;
+use PHPUnit\Framework\TestCase;
+
+class ModelTest extends TestCase
+{
+    public function testChatUsesDefaultModelWhenNotProvided(): void
+    {
+        // Test 1: Test chat uses default model when no model option supplied
+
+        $chatResponse = $this->createJsonResponse([
+            'id' => 'chat-default',
+            'object' => 'chat.completion',
+            'created' => time(),
+            'model' => 'grok-3',
+            'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 7, 'total_tokens' => 12],
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Hello from default model'],
+                'finish_reason' => 'stop',
+            ]],
+        ]);
+
+        $provider = $this->createProviderWithPostResponses($chatResponse);
+        $provider->setDefaultModel('grok-3');
+
+        $response = $provider->chat('Which model are you using?');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Hello from default model', $response->getContent());
+        $this->assertSame('grok-3', $response->getMetadata()['model']);
+    }
+
+    public function testChatOverridesDefaultModelWhenProvided(): void
+    {
+        // Test 2: Test chat overrides default model when explicit model provided
+
+        $chatResponse = $this->createJsonResponse([
+            'id' => 'chat-override',
+            'object' => 'chat.completion',
+            'created' => time(),
+            'model' => 'grok-3-fast',
+            'usage' => ['prompt_tokens' => 6, 'completion_tokens' => 8, 'total_tokens' => 14],
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Override acknowledged'],
+                'finish_reason' => 'stop',
+            ]],
+        ]);
+
+        $provider = $this->createProviderWithPostResponses($chatResponse);
+        $provider->setDefaultModel('grok-3-mini-fast');
+
+        $response = $provider->chat('Use a different model', ['model' => 'grok-3-fast']);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Override acknowledged', $response->getContent());
+        $this->assertSame('grok-3-fast', $response->getMetadata()['model']);
+    }
+
+    public function testUnsetDefaultModelRevertsToProviderDefault(): void
+    {
+        // Test 3: Test unsetDefaultModel reverts to provider default model
+
+        $chatResponse = $this->createJsonResponse([
+            'id' => 'chat-unset',
+            'object' => 'chat.completion',
+            'created' => time(),
+            'model' => 'grok-3-mini-fast',
+            'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 5, 'total_tokens' => 10],
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Back to default'],
+                'finish_reason' => 'stop',
+            ]],
+        ]);
+
+        $provider = $this->createProviderWithPostResponses($chatResponse);
+        $provider->setDefaultModel('grok-3');
+        $provider->unsetDefaultModel();
+
+        $this->assertNull($provider->getDefaultModel());
+
+        $response = $provider->chat('Hello');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testIsModelCapableReturnsCorrectResults(): void
+    {
+        // Test 4: Test isModelCapable returns correct results for each capability type
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+
+        $this->assertTrue($provider->isModelCapable('grok-3', 'chat'));
+        $this->assertTrue($provider->isModelCapable('grok-3-fast', 'chat'));
+        $this->assertTrue($provider->isModelCapable('grok-2-vision', 'vision'));
+        $this->assertTrue($provider->isModelCapable('grok-2-image', 'image'));
+        $this->assertTrue($provider->isModelCapable('v1', 'embedding'));
+
+        $this->assertFalse($provider->isModelCapable('grok-3', 'image'));
+        $this->assertFalse($provider->isModelCapable('grok-2-image', 'chat'));
+        $this->assertFalse($provider->isModelCapable('grok-3', 'nonexistent'));
+    }
+
+    public function testGetModelListsMethods(): void
+    {
+        // Test 5: Test model list methods return non-empty arrays with expected models
+
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $provider = new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+
+        $this->assertNotEmpty($provider->getChatModels());
+        $this->assertNotEmpty($provider->getVisionModels());
+        $this->assertNotEmpty($provider->getImageModels());
+        $this->assertNotEmpty($provider->getEmbeddingModels());
+
+        $this->assertContains('grok-3', $provider->getChatModels());
+        $this->assertContains('grok-2-vision', $provider->getVisionModels());
+        $this->assertContains('grok-2-image', $provider->getImageModels());
+        $this->assertContains('v1', $provider->getEmbeddingModels());
+    }
+
+    private function createProviderWithPostResponses(HttpResponse ...$responses): GrokProvider
+    {
+        $httpFactoryMock = $this->createMock(HttpFactory::class);
+        $httpClientMock = $this->createMock(Http::class);
+
+        $httpFactoryMock->method('getHttp')->willReturn($httpClientMock);
+
+        if (!empty($responses)) {
+            $httpClientMock->method('post')->willReturnOnConsecutiveCalls(...$responses);
+        }
+
+        return new GrokProvider(['api_key' => 'test-api-key'], $httpFactoryMock);
+    }
+
+    private function createJsonResponse(array $payload, int $status = 200): HttpResponse
+    {
+        $response = new HttpResponse('php://memory', $status, ['Content-Type' => 'application/json']);
+        $response->getBody()->write(json_encode($payload));
+
+        return $response;
+    }
+}

--- a/src/AIFactory.php
+++ b/src/AIFactory.php
@@ -12,6 +12,7 @@ namespace Joomla\AI;
 use Joomla\AI\Provider\OpenAIProvider;
 use Joomla\AI\Provider\AnthropicProvider;
 use Joomla\AI\Provider\OllamaProvider;
+use Joomla\AI\Provider\GrokProvider;
 use Joomla\AI\Exception\InvalidArgumentException;
 use Joomla\AI\Exception\ProviderException;
 
@@ -32,6 +33,7 @@ class AIFactory
         'openai' => OpenAIProvider::class,
         'anthropic' => AnthropicProvider::class,
         'ollama' => OllamaProvider::class,
+        'grok' => GrokProvider::class,
     ];
 
     /**

--- a/src/Provider/GrokProvider.php
+++ b/src/Provider/GrokProvider.php
@@ -1,0 +1,805 @@
+<?php
+
+/**
+ * Part of the Joomla Framework AI Package
+ *
+ * @copyright  Copyright (C) 2025 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\AI\Provider;
+
+use Joomla\AI\AbstractProvider;
+use Joomla\AI\Exception\AuthenticationException;
+use Joomla\AI\Exception\InvalidArgumentException;
+use Joomla\AI\Exception\ProviderException;
+use Joomla\AI\Interface\ProviderInterface;
+use Joomla\AI\Interface\ChatInterface;
+use Joomla\AI\Interface\EmbeddingInterface;
+use Joomla\AI\Interface\ImageInterface;
+use Joomla\AI\Interface\ModelInterface;
+use Joomla\AI\Response\Response;
+use Joomla\Http\HttpFactory;
+
+/**
+ * Grok (xAI) provider implementation.
+ *
+ * Grok uses an OpenAI-compatible API format with the base URL https://api.x.ai/v1.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class GrokProvider extends AbstractProvider implements ProviderInterface, ChatInterface, ImageInterface, EmbeddingInterface, ModelInterface
+{
+    /**
+     * Custom base URL for API requests
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private $baseUrl;
+
+    /**
+     * Models that support chat capability.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    private const CHAT_MODELS = [
+        'grok-3',
+        'grok-3-fast',
+        'grok-3-mini',
+        'grok-3-mini-fast',
+        'grok-2',
+        'grok-2-latest',
+    ];
+
+    /**
+     * Models that support vision capability.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    private const VISION_MODELS = [
+        'grok-2-vision',
+        'grok-2-vision-latest',
+    ];
+
+    /**
+     * Models that support image generation capability.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    private const IMAGE_MODELS = [
+        'grok-2-image',
+        'grok-2-image-latest',
+    ];
+
+    /**
+     * Models that support embedding capability.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    private const EMBEDDING_MODELS = [
+        'v1',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param   array|\ArrayAccess  $options     Provider options array.
+     * @param   HttpFactory         $httpFactory The http factory
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function __construct($options = [], ?HttpFactory $httpFactory = null)
+    {
+        parent::__construct($options, $httpFactory);
+
+        $this->baseUrl = $this->getOption('base_url', 'https://api.x.ai/v1');
+
+        // Remove trailing slash if present
+        if (substr($this->baseUrl, -1) === '/') {
+            $this->baseUrl = rtrim($this->baseUrl, '/');
+        }
+    }
+
+    /**
+     * Check if Grok provider is supported/configured.
+     *
+     * @return  boolean  True if API key is available
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function isSupported(): bool
+    {
+        return !empty($_ENV['XAI_API_KEY']) ||
+               !empty(getenv('XAI_API_KEY'));
+    }
+
+    /**
+     * Get the provider name.
+     *
+     * @return  string  The provider name
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getName(): string
+    {
+        return 'Grok';
+    }
+
+    /**
+     * Build HTTP headers for xAI API request.
+     *
+     * @return  array  HTTP headers
+     * @since  __DEPLOY_VERSION__
+     */
+    private function buildHeaders(): array
+    {
+        $apiKey = $this->getApiKey();
+
+        return [
+            'Authorization' => 'Bearer ' . $apiKey,
+            'Content-Type' => 'application/json',
+        ];
+    }
+
+    /**
+     * Get the xAI API key.
+     *
+     * @return  string  The API key
+     * @throws  AuthenticationException  If API key is not found
+     * @since  __DEPLOY_VERSION__
+     */
+    private function getApiKey(): string
+    {
+        $apiKey = $this->getOption('api_key') ??
+                  $_ENV['XAI_API_KEY'] ??
+                  getenv('XAI_API_KEY');
+
+        if (empty($apiKey)) {
+            throw new AuthenticationException(
+                $this->getName(),
+                ['message' => 'xAI API key not configured. Set XAI_API_KEY environment variable or provide api_key option.'],
+                401
+            );
+        }
+
+        return $apiKey;
+    }
+
+    /**
+     * Get the chat completions endpoint URL.
+     *
+     * @return  string  The endpoint URL
+     * @since  __DEPLOY_VERSION__
+     */
+    private function getChatEndpoint(): string
+    {
+        return $this->baseUrl . '/chat/completions';
+    }
+
+    /**
+     * Get the image generation endpoint URL.
+     *
+     * @return  string  The endpoint URL
+     * @since  __DEPLOY_VERSION__
+     */
+    private function getImageEndpoint(): string
+    {
+        return $this->baseUrl . '/images/generations';
+    }
+
+    /**
+     * Get the embeddings endpoint URL.
+     *
+     * @return  string  The endpoint URL
+     * @since  __DEPLOY_VERSION__
+     */
+    private function getEmbeddingsEndpoint(): string
+    {
+        return $this->baseUrl . '/embeddings';
+    }
+
+    /**
+     * Get the models endpoint URL.
+     *
+     * @return  string  The endpoint URL
+     * @since  __DEPLOY_VERSION__
+     */
+    private function getModelsEndpoint(): string
+    {
+        return $this->baseUrl . '/models';
+    }
+
+    /**
+     * List available models from xAI.
+     *
+     * @return  array
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getAvailableModels(): array
+    {
+        $headers = $this->buildHeaders();
+        $response = $this->makeGetRequest($this->getModelsEndpoint(), $headers);
+        $data = $this->parseJsonResponse($response->getBody());
+
+        return array_column($data['data'], 'id');
+    }
+
+    /**
+     * Get models that support chat capability.
+     *
+     * @return  array  Array of chat-capable model names
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getChatModels(): array
+    {
+        return self::CHAT_MODELS;
+    }
+
+    /**
+     * Get models that support vision capability.
+     *
+     * @return  array  Array of vision-capable model names
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getVisionModels(): array
+    {
+        return self::VISION_MODELS;
+    }
+
+    /**
+     * Get models that support image generation capability.
+     *
+     * @return  array  Array of image-capable model names
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getImageModels(): array
+    {
+        return self::IMAGE_MODELS;
+    }
+
+    /**
+     * Get available embedding models for this provider.
+     *
+     * @return  array  Array of available embedding model names
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getEmbeddingModels(): array
+    {
+        return self::EMBEDDING_MODELS;
+    }
+
+    /**
+     * Check if a model supports a specific capability.
+     *
+     * @param   string  $model       The model name to check
+     * @param   string  $capability  The capability to check (chat, vision, image, embedding)
+     *
+     * @return  bool    True if model supports the capability
+     * @since   __DEPLOY_VERSION__
+     */
+    public function isModelCapable(string $model, string $capability): bool
+    {
+        $capabilityMap = [
+            'chat' => self::CHAT_MODELS,
+            'vision' => self::VISION_MODELS,
+            'image' => self::IMAGE_MODELS,
+            'embedding' => self::EMBEDDING_MODELS,
+        ];
+
+        return $this->checkModelCapability($model, $capability, $capabilityMap);
+    }
+
+    /**
+     * Send a message to Grok and return response.
+     *
+     * @param   string  $message  The message to send
+     * @param   array   $options  Additional options for the request
+     *
+     * @return  Response  The AI response object
+     * @since  __DEPLOY_VERSION__
+     */
+    public function chat(string $message, array $options = []): Response
+    {
+        $payload = $this->buildChatRequestPayload($message, $options);
+
+        $headers = $this->buildHeaders();
+
+        $httpResponse = $this->makePostRequest(
+            $this->getChatEndpoint(),
+            json_encode($payload),
+            $headers
+        );
+
+        return $this->parseChatResponse($httpResponse->getBody());
+    }
+
+    /**
+     * Generate chat completion with vision capability and return Response.
+     *
+     * @param   string  $message  The chat message about the image.
+     * @param   string  $image    Image URL or base64 encoded image.
+     * @param   array   $options  Additional options for the request.
+     *
+     * @return  Response
+     * @since  __DEPLOY_VERSION__
+     */
+    public function vision(string $message, string $image, array $options = []): Response
+    {
+        $payload = $this->buildVisionRequestPayload($message, $image, $options);
+
+        $headers = $this->buildHeaders();
+
+        $httpResponse = $this->makePostRequest(
+            $this->getChatEndpoint(),
+            json_encode($payload),
+            $headers
+        );
+
+        return $this->parseChatResponse($httpResponse->getBody());
+    }
+
+    /**
+     * Generate an image from a text prompt.
+     *
+     * @param   string  $prompt   Descriptive text prompt for the desired image.
+     * @param   array   $options  Additional options for the request.
+     *
+     * @return  Response
+     * @since   __DEPLOY_VERSION__
+     */
+    public function generateImage(string $prompt, array $options = []): Response
+    {
+        $payload = $this->buildImageRequestPayload($prompt, $options);
+
+        $headers = $this->buildHeaders();
+
+        $httpResponse = $this->makePostRequest(
+            $this->getImageEndpoint(),
+            json_encode($payload),
+            $headers
+        );
+
+        return $this->parseImageResponse($httpResponse->getBody(), $payload);
+    }
+
+    /**
+     * Edit an existing image with a text prompt.
+     *
+     * Note: xAI Grok API does not currently support image editing.
+     * This method throws an exception indicating the limitation.
+     *
+     * @param   string  $imagePath  Path to the image file to modify.
+     * @param   string  $prompt     Text description of the desired modifications.
+     * @param   array   $options    Additional options for the request.
+     *
+     * @return  Response
+     * @throws  ProviderException  Always, as this capability is not supported
+     * @since   __DEPLOY_VERSION__
+     */
+    public function editImage($imagePath, string $prompt, array $options = []): Response
+    {
+        throw new ProviderException(
+            $this->getName(),
+            ['message' => 'Image editing is not supported by the Grok provider. Use generateImage() instead.']
+        );
+    }
+
+    /**
+     * Create variations of an image.
+     *
+     * Note: xAI Grok API does not currently support image variations.
+     * This method throws an exception indicating the limitation.
+     *
+     * @param   string  $imagePath  Path to the source image file.
+     * @param   array   $options    Additional options for the request.
+     *
+     * @return  Response
+     * @throws  ProviderException  Always, as this capability is not supported
+     * @since   __DEPLOY_VERSION__
+     */
+    public function createImageVariation(string $imagePath, array $options = []): Response
+    {
+        throw new ProviderException(
+            $this->getName(),
+            ['message' => 'Image variations are not supported by the Grok provider. Use generateImage() instead.']
+        );
+    }
+
+    /**
+     * Create embeddings for the given input text(s).
+     *
+     * @param   string|array  $input    Text string or array of texts to embed
+     * @param   string        $model    The embedding model to use
+     * @param   array         $options  Additional options
+     *
+     * @return  Response
+     * @since   __DEPLOY_VERSION__
+     */
+    public function createEmbeddings($input, string $model, array $options = []): Response
+    {
+        $payload = $this->buildEmbeddingPayload($input, $model, $options);
+
+        $headers = $this->buildHeaders();
+
+        $httpResponse = $this->makePostRequest(
+            $this->getEmbeddingsEndpoint(),
+            json_encode($payload),
+            $headers
+        );
+
+        return $this->parseEmbeddingResponse($httpResponse->getBody(), $payload);
+    }
+
+    /**
+     * Build payload for chat request.
+     *
+     * @param   string  $message  The user message to send
+     * @param   array   $options  Additional options
+     *
+     * @return  array   The request payload
+     * @since  __DEPLOY_VERSION__
+     */
+    private function buildChatRequestPayload(string $message, array $options = []): array
+    {
+        $model = $options['model'] ?? $this->defaultModel ?? $this->getOption('model', 'grok-3-mini-fast');
+
+        $messages = $options['messages'] ?? [
+            [
+                'role' => 'user',
+                'content' => $message,
+            ],
+        ];
+
+        $payload = [
+            'model' => $model,
+            'messages' => $messages,
+        ];
+
+        if (isset($options['max_tokens'])) {
+            $payload['max_tokens'] = (int) $options['max_tokens'];
+        }
+
+        if (isset($options['temperature'])) {
+            $payload['temperature'] = (float) $options['temperature'];
+        }
+
+        if (isset($options['top_p'])) {
+            $payload['top_p'] = (float) $options['top_p'];
+        }
+
+        if (isset($options['stop'])) {
+            $payload['stop'] = $options['stop'];
+        }
+
+        if (isset($options['frequency_penalty'])) {
+            $payload['frequency_penalty'] = (float) $options['frequency_penalty'];
+        }
+
+        if (isset($options['presence_penalty'])) {
+            $payload['presence_penalty'] = (float) $options['presence_penalty'];
+        }
+
+        if (isset($options['n'])) {
+            $payload['n'] = (int) $options['n'];
+        }
+
+        if (isset($options['stream'])) {
+            $payload['stream'] = (bool) $options['stream'];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Build payload for vision request.
+     *
+     * @param   string  $message  The chat message about the image
+     * @param   string  $image    Image URL or base64 encoded image
+     * @param   array   $options  Additional options
+     *
+     * @return  array   The request payload
+     * @since  __DEPLOY_VERSION__
+     */
+    private function buildVisionRequestPayload(string $message, string $image, array $options = []): array
+    {
+        $model = $options['model'] ?? $this->defaultModel ?? $this->getOption('model', 'grok-2-vision-latest');
+        $maxTokens = $options['max_tokens'] ?? 1024;
+
+        $imageUrl = $image;
+
+        $content = [
+            [
+                'type' => 'text',
+                'text' => $message,
+            ],
+            [
+                'type' => 'image_url',
+                'image_url' => [
+                    'url' => $imageUrl,
+                ],
+            ],
+        ];
+
+        $payload = [
+            'model' => $model,
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => $content,
+                ],
+            ],
+            'max_tokens' => $maxTokens,
+        ];
+
+        if (isset($options['temperature'])) {
+            $payload['temperature'] = (float) $options['temperature'];
+        }
+
+        if (isset($options['top_p'])) {
+            $payload['top_p'] = (float) $options['top_p'];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Build payload for image generation request.
+     *
+     * @param   string  $prompt   The image generation prompt
+     * @param   array   $options  Additional options
+     *
+     * @return  array  The request payload
+     * @since   __DEPLOY_VERSION__
+     */
+    private function buildImageRequestPayload(string $prompt, array $options): array
+    {
+        $model = $options['model'] ?? $this->defaultModel ?? $this->getOption('model', 'grok-2-image-latest');
+
+        $payload = [
+            'model' => $model,
+            'prompt' => $prompt,
+        ];
+
+        if (isset($options['n'])) {
+            $n = (int) $options['n'];
+            if ($n < 1 || $n > 10) {
+                throw InvalidArgumentException::invalidParameter('n', $options['n'], 'grok', 'Parameter "n" must be between 1 and 10.', ['min_value' => 1, 'max_value' => 10]);
+            }
+            $payload['n'] = $n;
+        }
+
+        if (isset($options['response_format'])) {
+            if (!in_array($options['response_format'], ['url', 'b64_json'])) {
+                throw InvalidArgumentException::invalidParameter('response_format', $options['response_format'], 'grok', 'Response format must be either "url" or "b64_json".', ['valid_values' => ['url', 'b64_json']]);
+            }
+            $payload['response_format'] = $options['response_format'];
+        }
+
+        if (isset($options['size'])) {
+            $payload['size'] = $options['size'];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Build request payload for embeddings.
+     *
+     * @param   string|array  $input    Text input(s) to embed
+     * @param   string        $model    The embedding model to use
+     * @param   array         $options  Additional options
+     *
+     * @return  array
+     * @since   __DEPLOY_VERSION__
+     */
+    private function buildEmbeddingPayload($input, string $model, array $options): array
+    {
+        $payload = [
+            'input' => $input,
+            'model' => $model,
+        ];
+
+        if (isset($options['encoding_format'])) {
+            if (!in_array($options['encoding_format'], ['float', 'base64'])) {
+                throw InvalidArgumentException::invalidParameter('encoding_format', $options['encoding_format'], 'grok', "Encoding format must be 'float' or 'base64'.");
+            }
+            $payload['encoding_format'] = $options['encoding_format'];
+        }
+
+        if (isset($options['dimensions'])) {
+            $payload['dimensions'] = (int) $options['dimensions'];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Parse xAI chat API response into unified Response object.
+     *
+     * @param   string  $responseBody  The JSON response body
+     *
+     * @return  Response  Unified response object
+     * @since  __DEPLOY_VERSION__
+     */
+    private function parseChatResponse(string $responseBody): Response
+    {
+        $data = $this->parseJsonResponse($responseBody);
+
+        if (isset($data['error'])) {
+            throw new ProviderException($this->getName(), $data);
+        }
+
+        $content = $data['choices'][0]['message']['content'] ?? '';
+
+        $statusCode = $this->determineAIStatusCode($data);
+
+        $metadata = [
+            'model' => $data['model'],
+            'usage' => $data['usage'] ?? [],
+            'finish_reason' => $data['choices'][0]['finish_reason'],
+            'created' => $data['created'] ?? time(),
+            'id' => $data['id'],
+            'choices' => $data['choices'],
+        ];
+
+        return new Response(
+            $content,
+            $this->getName(),
+            $metadata,
+            $statusCode
+        );
+    }
+
+    /**
+     * Parse xAI Image API response into unified Response object.
+     *
+     * @param   string  $responseBody  The JSON response body
+     * @param   array   $payload       The original request payload
+     *
+     * @return  Response  Unified response object
+     * @since  __DEPLOY_VERSION__
+     */
+    private function parseImageResponse(string $responseBody, array $payload): Response
+    {
+        $data = $this->parseJsonResponse($responseBody);
+
+        if (isset($data['error'])) {
+            throw new ProviderException($this->getName(), $data);
+        }
+
+        $images = [];
+        $responseFormat = '';
+
+        if (isset($data['data']) && is_array($data['data'])) {
+            foreach ($data['data'] as $imageData) {
+                $imageItem = [];
+
+                if (isset($imageData['url'])) {
+                    $imageItem['url'] = $imageData['url'];
+                    $responseFormat = 'url';
+                }
+
+                if (isset($imageData['b64_json'])) {
+                    $imageItem['b64_json'] = $imageData['b64_json'];
+                    $responseFormat = 'b64_json';
+                }
+
+                if (isset($imageData['revised_prompt'])) {
+                    $imageItem['revised_prompt'] = $imageData['revised_prompt'];
+                }
+
+                $images[] = $imageItem;
+            }
+        }
+
+        $content = '';
+        if ($responseFormat === 'url') {
+            $urls = array_column($images, 'url');
+            $content = count($urls) === 1 ? $urls[0] : json_encode($urls, JSON_PRETTY_PRINT);
+        } elseif ($responseFormat === 'b64_json') {
+            $base64Data = array_column($images, 'b64_json');
+            $content = count($base64Data) === 1 ? $base64Data[0] : json_encode($base64Data, JSON_PRETTY_PRINT);
+        }
+
+        $metadata = [
+            'model' => $data['model'] ?? $payload['model'],
+            'created' => $data['created'] ?? time(),
+            'response_format' => $responseFormat,
+            'image_count' => count($images),
+            'images' => $images,
+        ];
+
+        if (isset($data['usage'])) {
+            $metadata['usage'] = $data['usage'];
+        }
+
+        return new Response(
+            $content,
+            $this->getName(),
+            $metadata,
+            200
+        );
+    }
+
+    /**
+     * Parse xAI Embeddings API response into unified Response object.
+     *
+     * @param   string  $responseBody  The JSON response body
+     * @param   array   $payload       The original request payload
+     *
+     * @return  Response
+     * @since  __DEPLOY_VERSION__
+     */
+    private function parseEmbeddingResponse(string $responseBody, array $payload): Response
+    {
+        $data = $this->parseJsonResponse($responseBody);
+
+        if (isset($data['error'])) {
+            throw new ProviderException($this->getName(), $data);
+        }
+
+        $embeddings = [];
+        if (isset($data['data']) && is_array($data['data'])) {
+            foreach ($data['data'] as $embeddingData) {
+                $embeddings[] = [
+                    'embedding' => $embeddingData['embedding'],
+                    'index' => $embeddingData['index'],
+                    'object' => $embeddingData['object'],
+                ];
+            }
+        }
+
+        $contentData = count($embeddings) === 1 ? $embeddings[0]['embedding'] : $embeddings;
+        $content = json_encode($contentData);
+
+        $metadata = [
+            'model' => $data['model'] ?? $payload['model'],
+            'object' => $data['object'] ?? 'list',
+            'embedding_count' => count($embeddings),
+            'encoding_format' => $payload['encoding_format'] ?? 'float',
+            'input_type' => is_array($payload['input']) ? 'array' : 'string',
+            'raw_embeddings' => $embeddings,
+        ];
+
+        if (isset($data['usage'])) {
+            $metadata['usage'] = $data['usage'];
+        }
+
+        return new Response(
+            $content,
+            $this->getName(),
+            $metadata,
+            200
+        );
+    }
+
+    /**
+     * Determine status code based on finish_reason.
+     *
+     * @param   array  $data  Parsed response
+     *
+     * @return  int  Status code
+     * @since  __DEPLOY_VERSION__
+     */
+    private function determineAIStatusCode(array $data): int
+    {
+        $finishReason = $data['choices'][0]['finish_reason'] ?? null;
+
+        switch ($finishReason) {
+            case 'stop':
+                return 200;
+            case 'length':
+                return 206;
+            case 'content_filter':
+                return 422;
+            case 'tool_calls':
+            case 'function_call':
+                return 202;
+            default:
+                return 200;
+        }
+    }
+}


### PR DESCRIPTION
Pull Request for Issue #11 

### Summary of Changes

Added GrokProvider class with core functionality:
- Supports the /v1/chat/completions endpoint for chat completions using Grok models                                                         
- Supports the /v1/chat/completions endpoint for vision capability
- Supports the /v1/images/generations endpoint for image generation (grok-2-image, grok-2-image-latest)
- Supports the /v1/embeddings endpoint for text embeddings (v1 model)
- Supports the /v1/models endpoint for listing available models

### Testing Instructions
Added unit tests for each capability in tests/GrokProvider/

### Documentation Changes Required
  - Update the framework documentation to include grok as an available provider
  - Document the XAI_API_KEY environment variable requirement
  - Add usage examples for chat, vision, image generation, and embeddings with Grok
